### PR TITLE
Fix typos in comments documentation

### DIFF
--- a/guides/hack/02-source-code-fundamentals/10-comments.md
+++ b/guides/hack/02-source-code-fundamentals/10-comments.md
@@ -2,7 +2,7 @@ There are two forms of comments: delimited and single-line.  For example:
 
 @@ comments-examples/show-comment-styles.php @@
 
-A *delimited comment* starts with `\*` and ends with `*/`, and may span source lines. It may contain any characters except 
+A *delimited comment* starts with `/*` and ends with `*/`, and may span source lines. It may contain any characters except 
 the sequence `*/`. A delimited comment may occur in *any* place in a script in which white space may occur. For example:
 
 ```Hack
@@ -32,4 +32,4 @@ A *single-line comment* starts with `//` or `#`, and ends with a new line, which
 A number of special comments are recognized; they are:
 * [`// FALLTHROUGH`](../statements/switch.md)
 * [`// strict`](program-structure.md)
-* `/* HH_IGNORE_ERROR [`*nnn*`] */`, where *nnn* is the compiler error number that is to be ignored.
+* `/* HH_IGNORE_ERROR[`*nnn*`] */`, where *nnn* is the compiler error number that is to be ignored.


### PR DESCRIPTION
- Delimited comments use `/*`, not `\*`
- No space between `HH_IGNORE_ERROR` and `[` (As evidenced by [the hhvm repo itself](https://github.com/facebook/hhvm/search?q=HH_IGNORE_ERROR))

